### PR TITLE
Add wink auth middleware to horizon.

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -1,4 +1,5 @@
 <?php
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -58,7 +59,7 @@ return [
     | the existing middleware. Or, you can simply stick with this list.
     |
     */
-    'middleware' => ['web'],
+    'middleware' => ['web', 'auth:wink'],
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
- Add wink auth middleware to horizon. (User must be logged in via wink to view Horizon dashboard)