### PR TITLE
Change body column of news table to text type.

### DIFF
--- a/database/migrations/2020_05_03_225919_chang_news_body_to_text.php
+++ b/database/migrations/2020_05_03_225919_chang_news_body_to_text.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangNewsBodyToText extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('news', function (Blueprint $table) {
+            $table->text('body')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('news', function (Blueprint $table) {
+            $table->string('body')->change();
+        });
+    }
+}


### PR DESCRIPTION
- Change body column of news table to text type, to allow for longer news posts.